### PR TITLE
Fix major issue with tokens leaking

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ const Parser = require('url');
 const Https = require('https');
 const Qs = require('querystring');
 const HEADERS = {};
-const PARAMS = { VERSION: '52.0' };
 
 function Paypal(username, password, signature, returnUrl, cancelUrl, debug) {
 	this.username = username;
@@ -17,11 +16,12 @@ function Paypal(username, password, signature, returnUrl, cancelUrl, debug) {
 };
 
 Paypal.prototype.params = function() {
-	var self = this;
-	PARAMS.USER = self.username;
-	PARAMS.PWD = self.password;
-	PARAMS.SIGNATURE = self.signature;
-	PARAMS.SOLUTIONTYPE = self.solutiontype;
+	const PARAMS = {};
+	PARAMS.VERSION = '52.0';
+	PARAMS.USER = this.username;
+	PARAMS.PWD = this.password;
+	PARAMS.SIGNATURE = this.signature;
+	PARAMS.SOLUTIONTYPE = this.solutiontype;
 	return PARAMS;
 };
 


### PR DESCRIPTION
I've spent the last few days on this and I've finally found why my check-out process is broken.  

I would have a customer buy a product with paypal and it would work fine. Then the second person who came along, I'd get this error from PayPal:

> Error: ACK Failure: A successful transaction has already been completed for this token.

This is because the Params object is global to the module - the function just reaches outside and returns it instead of creating a new one, and when you add `token` to the params object, it sticks around for the next person to use it. Thus customer #2 sends customer #1's token along for the ride and PayPal (which isn't expecting a token) complains that it's already been used. 

So yeah - this is a pretty major issue. I've fixed it on my server but would be great to have it pushed to npm.